### PR TITLE
Fix flexform related bug with new form engine and IRRE

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -31,6 +31,14 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['formDataGroup']['tcaDatabaseRe
 	)
 );
 
+// Cache required to fix flexform related bug with new form engine and IRRE
+if (!is_array($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations'][$_EXTKEY])) {
+	$GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations'][$_EXTKEY] = array(
+		'frontend' => \TYPO3\CMS\Core\Cache\Frontend\VariableFrontend::class,
+		'groups' => array('system')
+	);
+}
+
 // @todo test the IRRE functionality
 // @todo update the documentation
 // @todo update the README.md (for git etc)


### PR DESCRIPTION
With the new form engine the proper initialization of pi_flexform is not done by the core. For handling IRRE records the parent record is required, which cannot be determined due to lack of proper initialization. Therefore generation of TCA with correct pi_flexform configuration has to be done in the extension itself.
