### PR TITLE
Avoid caching of incomplete data structure array

### DIFF
--- a/Classes/Hooks/Form/FlexFormDs.php
+++ b/Classes/Hooks/Form/FlexFormDs.php
@@ -63,7 +63,7 @@ class FlexFormDs {
 
         // Restore dataStructArray from cache if necessary
         $cachedDataStructArray = $cache->get($cacheIdentifier);
-        if (!array_key_exists('uid', $row) && $cachedDataStructArray) {
+        if (!array_key_exists('pi_flexform', $row) && $cachedDataStructArray) {
             $dataStructArray = $cachedDataStructArray;
             return true;
         }


### PR DESCRIPTION
Under certain circumstances an empty data structure array is cached. This situation is caused if system cache is cleared during an IRRE record is added (e.g.: Create new relation > Flush system caches > Choose image). With this fix the cached data structure is used only if the data structure cannot be generated (for IRRE records).
