### PR TITLE
Check for valid table and/or CType to avoid errors

### DIFF
--- a/Classes/Hooks/Form/FlexFormDs.php
+++ b/Classes/Hooks/Form/FlexFormDs.php
@@ -56,6 +56,11 @@ class FlexFormDs {
      * @param $fieldName
      */
     public function getFlexFormDS_postProcessDS(&$dataStructArray, &$conf, &$row, &$table, &$fieldName) {
+        // Check for valid table and/or CType
+        if ($table != 'tt_content' || !is_array($row) || !array_key_exists('CType', $row) || !strlen($row['CType'])) {
+            return false;
+        }
+
         // Init cache
         $objectManager = GeneralUtility::makeInstance(ObjectManager::class);
         $cache = $objectManager->get(CacheManager::class, $objectManager)->getCache('content_designer');


### PR DESCRIPTION
The hook is called for tables other than tt_content too, e.g. for Storages. Because the hook is based on the field CType (tt_content only) this leads to an error. This fix checks for valid settings beforehand.
